### PR TITLE
Update blocked-export docs with steps for dealing with flaky tests

### DIFF
--- a/docs/blocked-export.md
+++ b/docs/blocked-export.md
@@ -15,7 +15,7 @@ Follow these steps (see [#23617](https://github.com/web-platform-tests/wpt/pull/
 - reference the new bug in the PR.
 - force merge the PR.
 
-Another common cause of failure is that [when many tests are affected, TaskCluster jobs will time out](https://github.com/web-platform-tests/wpt/issues/7660). The timeout is at around 50 minutes. When this happens, the PR has to be force merged. Link to [#7660](https://github.com/web-platform-tests/wpt/issues/7660) in a comment and ask @stephenmcgruer or @Hexcles to merge the PR.
+Another common cause of failure is that [when many tests are affected, TaskCluster jobs will time out](https://github.com/web-platform-tests/wpt/issues/7660). The timeout is at around 120 minutes. When this happens, the PR has to be force merged. Link to [#7660](https://github.com/web-platform-tests/wpt/issues/7660) in a comment and ask @stephenmcgruer or @Hexcles to merge the PR.
 
 If the failure looks unrelated to the code changes, first rebase and force push the branch. This will both bring in any recent fixes to the problem and trigger a new TaskCluster run. If that doesn't fix the problem and other PRs are also affected, [file a wpt infra bug](https://github.com/web-platform-tests/wpt/issues/new?labels=infra).
 

--- a/docs/blocked-export.md
+++ b/docs/blocked-export.md
@@ -8,10 +8,10 @@ require help from the author, so unflaking these can take some time. To avoid
 these PRs from piling up we aim to clear them from the queue and apply a fix in
 the background.
 
-Follow these steps (see [#23617](https://github.com/web-platform-tests/wpt/pull/23617) for a recent example:
+Follow these steps (see [#23617](https://github.com/web-platform-tests/wpt/pull/23617) for a recent example):
 - copy the "Unstable Results" from the TaskCluster log into the PR for easier
   viewing.
-- create a crbug to record the flake (point to the PR and assign to the CL author.
+- create a crbug to record the flake, which should point to the PR and be assigned to the CL author.
 - reference the new bug in the PR.
 - force merge the PR.
 

--- a/docs/blocked-export.md
+++ b/docs/blocked-export.md
@@ -4,7 +4,7 @@ Usually this is caused by failing TaskCluster checks. Read the TaskCluster logs 
 
 A common problem is the TaskCluster stability check failing, which indicates
 that a test is flaky. This is very often a problem with the test itself and will
-require help from the author, so unflaking these can take some time. To avoid
+require help from the author, so deflaking these can take some time. To avoid
 these PRs from piling up we aim to clear them from the queue and apply a fix in
 the background.
 
@@ -15,9 +15,7 @@ Follow these steps (see [#23617](https://github.com/web-platform-tests/wpt/pull/
 - reference the new bug in the PR.
 - force merge the PR.
 
-Another common cause of failure is that [when many tests are affected, TaskCluster jobs will time out](https://github.com/web-platform-tests/wpt/issues/7660). The timeout is at around 50 minutes. When this happens, the PR has to be force merged. Link to [#7660](https://github.com/web-platform-tests/wpt/issues/7660) in a comment and ask @foolip or @Hexcles to merge the PR.
-
-If the test is flaky, try to reproduce the flakiness locally and if necessary ask the original CL author for help.
+Another common cause of failure is that [when many tests are affected, TaskCluster jobs will time out](https://github.com/web-platform-tests/wpt/issues/7660). The timeout is at around 50 minutes. When this happens, the PR has to be force merged. Link to [#7660](https://github.com/web-platform-tests/wpt/issues/7660) in a comment and ask @stephenmcgruer or @Hexcles to merge the PR.
 
 If the failure looks unrelated to the code changes, first rebase and force push the branch. This will both bring in any recent fixes to the problem and trigger a new TaskCluster run. If that doesn't fix the problem and other PRs are also affected, [file a wpt infra bug](https://github.com/web-platform-tests/wpt/issues/new?labels=infra).
 

--- a/docs/blocked-export.md
+++ b/docs/blocked-export.md
@@ -1,12 +1,25 @@
 These are export PRs which the exporter should have merged by now.
 
-Usually this is caused by failing Travis checks. Read the Travis logs to understand the failure.
+Usually this is caused by failing TaskCluster checks. Read the TaskCluster logs to understand the failure.
 
-A common cause of failure is that [when many tests are affected, Travis jobs will time out](https://github.com/web-platform-tests/wpt/issues/7660). The timeout is at around 50 minutes. When this happens, the PR has to be force merged. Link to [#7660](https://github.com/web-platform-tests/wpt/issues/7660) in a comment and ask @stephenmcgruer or @Hexcles to merge the PR.
+A common problem is the TaskCluster stability check failing, which indicates
+that a test is flaky. This is very often a problem with the test itself and will
+require help from the author, so unflaking these can take some time. To avoid
+these PRs from piling up we aim to clear them from the queue and apply a fix in
+the background.
+
+Follow these steps (see [#23617](https://github.com/web-platform-tests/wpt/pull/23617) for a recent example:
+- copy the "Unstable Results" from the TaskCluster log into the PR for easier
+  viewing.
+- create a crbug to record the flake (point to the PR and assign to the CL author.
+- reference the new bug in the PR.
+- force merge the PR.
+
+Another common cause of failure is that [when many tests are affected, TaskCluster jobs will time out](https://github.com/web-platform-tests/wpt/issues/7660). The timeout is at around 50 minutes. When this happens, the PR has to be force merged. Link to [#7660](https://github.com/web-platform-tests/wpt/issues/7660) in a comment and ask @foolip or @Hexcles to merge the PR.
 
 If the test is flaky, try to reproduce the flakiness locally and if necessary ask the original CL author for help.
 
-If the failure looks unrelated to the code changes, first rebase and force push the branch. This will both bring in any recent fixes to the problem and trigger a new Travis run. If that doesn't fix the problem and other PRs are also affected, [file a wpt infra bug](https://github.com/web-platform-tests/wpt/issues/new?labels=infra).
+If the failure looks unrelated to the code changes, first rebase and force push the branch. This will both bring in any recent fixes to the problem and trigger a new TaskCluster run. If that doesn't fix the problem and other PRs are also affected, [file a wpt infra bug](https://github.com/web-platform-tests/wpt/issues/new?labels=infra).
 
 If there are merge conflicts, try to rebase the branch and force push. If the conflicts are non-trivial, again, ask the original author for help.
 


### PR DESCRIPTION
To deal with flakes we'll now file a bug and merge the PR. 

This PR also replace usage of 'Travis' with 'TaskCluster'