### PR TITLE
Remove Blink>Infra>Ecosystem P2 section

### DIFF
--- a/docs/crbug-p2.md
+++ b/docs/crbug-p2.md
@@ -1,1 +1,0 @@
-Make sure there is an owner and ask for an update.

--- a/webapp/components/ecosystem-infra-rotation.html
+++ b/webapp/components/ecosystem-infra-rotation.html
@@ -185,11 +185,6 @@
             query: 'component:Blink>Infra>Ecosystem Pri=1 modified<today-30',
             docs: 'crbug-p1.md',
           },
-          {
-            name: 'P2 issues >60 days',
-            query: 'component:Blink>Infra>Ecosystem Pri=2 modified<today-60',
-            docs: 'crbug-p2.md',
-          },
         ];
 
         const fyiTaskInfo = [


### PR DESCRIPTION
Historically (and unsurprisingly), pinging bugs and asking for updates has not been effective, and so this section is basically ignored. Let's make that official.