### PR TITLE
Update ecosystem-infra-rotation.html

### DIFF
--- a/webapp/components/ecosystem-infra-rotation.html
+++ b/webapp/components/ecosystem-infra-rotation.html
@@ -131,7 +131,7 @@
           importExportTask('export'),
           githubTask({
             name: 'blocked export PRs',
-            query: `is:pr is:open label:chromium-export -label:"do not merge yet" updated:<${minutesAgo(50)}`,
+            query: `is:pr is:open label:chromium-export -label:"do not merge yet" updated:<${minutesAgo(50)} review:approved`,
             docs: 'blocked-export.md',
           }),
         ];


### PR DESCRIPTION
Updates the blocked export PR query to only include the PRs that are only approved.

In particular, this updated query will exclude PRs that still need manual review by the Interop team.

Question for the reviewer: Do we still want to track those PRs where human review is still needed? Maybe because of some reason they need a nudge from us? If so, we should probably think of another way to handle this.

Another note: The exporter process itself has the ability to read the live description from GitHub. So we can change it after the merge. However, the check for exportable CLs in the importer process only looks at the [description in the merged commit](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/tools/blinkpy/w3c/chromium_exportable_commits.py;l=173-177;drc=a761975423714716ae027610a114977f904f2d28), not from GitHub.