### PR TITLE
feat: Differentiate between stable and experimental mobile runs

### DIFF
--- a/docs/wpt.fyi-mobile-experimental.md
+++ b/docs/wpt.fyi-mobile-experimental.md
@@ -1,7 +1,7 @@
-Runs for mobile Chrome and Firefox should happen at least daily.
+Experimental runs for mobile Chrome and Firefox should happen at least daily.
 
 If this check fails, file an issue on [wpt.fyi](https://github.com/web-platform-tests/wpt.fyi) if all runs are affected, or [wpt](https://github.com/web-platform-tests/wpt) with the [infra label](https://github.com/web-platform-tests/wpt/labels/infra) if only some runs are missing. To check for issues on recent runs go to [wpt.fyi/status](https://wpt.fyi/status), select the `Invalid runs` tab, and then click on `Show error`. If the issue is with the WPT CI, then it's best to file an issue in the wpt repo, even in the case of all engines being affected.
 
 Contact points for the underlying runner infrastructure:
-* Chrome - [@WeizhongX](https://github.com/WeizhongX) (Chromium CI)
+* Chrome Android and Chrome iOS - [@jonathan-j-lee](https://github.com/jonathan-j-lee) (Chromium CI)
 * Firefox - [@jgraham](http://github.com/jgraham) (Taskcluster)

--- a/docs/wpt.fyi-mobile-stable.md
+++ b/docs/wpt.fyi-mobile-stable.md
@@ -1,0 +1,7 @@
+Stable runs for mobile Chrome and Firefox should happen at least daily.
+
+If this check fails, file an issue on [wpt.fyi](https://github.com/web-platform-tests/wpt.fyi) if all runs are affected, or [wpt](https://github.com/web-platform-tests/wpt) with the [infra label](https://github.com/web-platform-tests/wpt/labels/infra) if only some runs are missing. To check for issues on recent runs go to [wpt.fyi/status](https://wpt.fyi/status), select the `Invalid runs` tab, and then click on `Show error`. If the issue is with the WPT CI, then it's best to file an issue in the wpt repo, even in the case of all engines being affected.
+
+Contact points for the underlying runner infrastructure:
+* Chrome Android - [@jonathan-j-lee](https://github.com/jonathan-j-lee) (Chromium CI)
+* Firefox - [@jgraham](http://github.com/jgraham) (Taskcluster)

--- a/webapp/components/ecosystem-infra-rotation.html
+++ b/webapp/components/ecosystem-infra-rotation.html
@@ -168,10 +168,16 @@
             docs: 'wpt.fyi-experimental.md',
           },
           {
-            name: 'mobile',
+            name: 'mobile-stable',
+            query: 'labels=master,stable&products=chrome_android,firefox_android',
+            maxAge: 24 * 3600,
+            docs: 'wpt.fyi-mobile-stable.md',
+          },
+          {
+            name: 'mobile-experimental',
             query: 'labels=master,experimental&products=chrome_android,firefox_android,chrome_ios',
             maxAge: 24 * 3600,
-            docs: 'wpt.fyi-mobile.md',
+            docs: 'wpt.fyi-mobile-experimental.md',
           },
         ];
 


### PR DESCRIPTION
This change introduces a distinction between stable and experimental mobile runs for wpt.fyi.

A new mobile-stable check is added to the ecosystem-infra-rotation component. The existing mobile check is renamed to mobile-experimental. The documentation is updated to reflect these changes.